### PR TITLE
fix: add spalidate installation to semantic-release workflow

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Install wrench
         run: go install github.com/cloudspannerecosystem/wrench@latest
         
+      - name: Install spalidate
+        run: go install github.com/nu0ma/spalidate@latest
+        
       - name: Install dependencies
         run: npm clean-install
         


### PR DESCRIPTION
## Summary
- Add missing `spalidate` tool installation to the semantic-release workflow
- This fixes the failing release CI that occurs when semantic-release runs the E2E tests

## Problem
The release CI was failing because:
1. The `spalidate` tool was added as a dependency in commit 75e638a (feat: use spalidate for db records validation)
2. The CI workflow was updated to install `spalidate`, but the semantic-release workflow was not
3. When the release workflow runs `npm test`, it creates a test project that requires `spalidate` during `make init`

## Solution
Added the same `spalidate` installation step to the semantic-release workflow that exists in the CI workflow.

## Test plan
- [x] Verified the CI workflow has the `spalidate` installation step
- [x] Added the same installation step to semantic-release workflow
- [ ] The release CI should pass after this change is merged