### PR TITLE
refactor: remove test-bed related code and references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,9 +165,6 @@ go.work.sum
 # Template validation temporary files
 .temp-validation/
 
-dev-testbed/
-# Extra safety for dev-testbed env files
-dev-testbed/**/.env*
 
 # Test CLI directories (temporary project generations)
 test-cli/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,5 @@
 dist/
 node_modules/
-dev-testbed/
 template/
 *.md
 *.yml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,8 +165,7 @@ npm run update-go-version 1.24.3
 
 # Validate and test changes
 npm run template:validate
-npm run dev:create-testbed
-npm run dev:test-e2e
+npm test
 ```
 
 ### Automated Version Updates
@@ -204,10 +203,9 @@ The automation updates Go version references in:
    npm run template:validate
    ```
 
-3. **Test with testbed**:
+3. **Run E2E tests**:
    ```bash
-   npm run dev:create-testbed
-   npm run dev:test-e2e
+   npm test
    ```
 
 4. **Commit changes** after validation passes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,6 @@ npm test
 - `src/` - CLI generator source code
 - `template/` - Project template files
 - `scripts/` - Development and validation scripts
-- `dev-testbed/` - Generated test project (auto-created)
 
 ## Contributing Guidelines
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -58,7 +58,6 @@ We take security seriously. If you discover a security vulnerability, please rep
 - **Dependency Management**: Dependencies are pinned to specific versions where possible
 
 ### Development Environment
-- **Testbed Isolation**: Development testbed creates temporary files that are automatically cleaned up
 - **Environment Variables**: Sensitive development configuration is kept in `.env` files that are gitignored
 - **Docker Isolation**: Emulator containers are isolated from the host system
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -36,7 +36,6 @@ export default [
     ignores: [
       'dist/**/*',
       'node_modules/**/*',
-      'dev-testbed/**/*',
       'template/**/*',
     ],
   },


### PR DESCRIPTION
## Summary
- Removed all test-bed related code and references from the project
- The test-bed functionality was redundant since `npm test` already provides comprehensive E2E testing

## Changes
- Deleted `dev-testbed/` directory
- Removed test-bed references from configuration files:
  - `.gitignore`
  - `.prettierignore`
  - `eslint.config.mjs`
  - `.claude/settings.local.json`
- Updated `CLAUDE.md` to use `npm test` instead of test-bed commands
- Cleaned up documentation:
  - `CONTRIBUTING.md`: Removed dev-testbed from project structure
  - `SECURITY.md`: Removed Testbed Isolation section

## Rationale
The test-bed was unnecessary because:
1. `npm test` runs the actual CLI to generate a project
2. It then runs `make run-all-scenarios` on the generated project
3. This provides the same validation as test-bed with less complexity

## Test plan
- [x] Run `npm test` to verify E2E tests still pass
- [x] Verify all test-bed references are removed
- [x] Check that development workflow is not affected