### PR TITLE
feat: add verbose flag to spalidate for better validation debugging

### DIFF
--- a/template/Makefile
+++ b/template/Makefile
@@ -153,14 +153,14 @@ validate-scenario: ## Validate scenario database state
 	@if ! docker ps | grep -q $(DOCKER_CONTAINER_NAME); then echo "❌ Emulator not running for validation"; exit 1; fi
 	@if [ -f "scenarios/$(SCENARIO)/expected-primary.yaml" ]; then \
 		echo "🔍 Validating primary database for $(SCENARIO)..."; \
-		SPANNER_EMULATOR_HOST=localhost:$(DOCKER_SPANNER_PORT) spalidate --project $(PROJECT_ID) --instance $(INSTANCE_ID) --database $(PRIMARY_DB_ID) scenarios/$(SCENARIO)/expected-primary.yaml || { echo "❌ Primary database validation failed for $(SCENARIO)"; exit 1; }; \
+		SPANNER_EMULATOR_HOST=localhost:$(DOCKER_SPANNER_PORT) spalidate --project $(PROJECT_ID) --instance $(INSTANCE_ID) --database $(PRIMARY_DB_ID) --verbose scenarios/$(SCENARIO)/expected-primary.yaml || { echo "❌ Primary database validation failed for $(SCENARIO)"; exit 1; }; \
 	else \
 		echo "⚠️ No primary validation file found for $(SCENARIO)"; \
 	fi
 ifeq ($(DB_COUNT),2)
 	@if [ -f "scenarios/$(SCENARIO)/expected-secondary.yaml" ]; then \
 		echo "🔍 Validating secondary database for $(SCENARIO)..."; \
-		SPANNER_EMULATOR_HOST=localhost:$(DOCKER_SPANNER_PORT) spalidate --project $(PROJECT_ID) --instance $(INSTANCE_ID) --database $(SECONDARY_DB_ID) scenarios/$(SCENARIO)/expected-secondary.yaml || { echo "❌ Secondary database validation failed for $(SCENARIO)"; exit 1; }; \
+		SPANNER_EMULATOR_HOST=localhost:$(DOCKER_SPANNER_PORT) spalidate --project $(PROJECT_ID) --instance $(INSTANCE_ID) --database $(SECONDARY_DB_ID) --verbose scenarios/$(SCENARIO)/expected-secondary.yaml || { echo "❌ Secondary database validation failed for $(SCENARIO)"; exit 1; }; \
 	else \
 		echo "⚠️ No secondary validation file found for $(SCENARIO)"; \
 	fi

--- a/template/tests/test-utils.ts
+++ b/template/tests/test-utils.ts
@@ -80,6 +80,7 @@ export function validateWithSpalidate(scenario: string, database: 'primary' | 's
       '--project', projectId,
       '--instance', instanceId,
       '--database', targetDatabaseId,
+      '--verbose',
       validationFile
     ], { 
       encoding: 'utf-8',


### PR DESCRIPTION
## Summary
• Add `--verbose` flag to spalidate calls in Makefile and TypeScript test utilities
• Enable detailed validation failure output showing specific table/column differences
• Improve debugging experience for database validation failures

## Changes
• **Makefile**: Added `--verbose` flag to both primary and secondary database validation commands
• **test-utils.ts**: Added `--verbose` flag to `validateWithSpalidate` function

## Benefits
• Better error visibility when validation fails
• Shows expected vs actual values for specific columns
• Displays table-level and column-level validation details
• Faster debugging of database validation issues

## Test plan
- [ ] Run `make validate-scenario` with failing validation to verify detailed output
- [ ] Run Playwright tests with validation failures to confirm enhanced error reporting
- [ ] Verify backward compatibility with existing validation workflows