### PR TITLE
Fix Docker container and database conflict errors in test execution

### DIFF
--- a/examples/two-databases/Makefile
+++ b/examples/two-databases/Makefile
@@ -43,13 +43,14 @@ setup-playwright: ## Setup Playwright
 	@npx playwright install
 	@echo "✅ Playwright setup complete"
 
-start: ## Start Spanner emulator
-	@echo "🐳 Starting Spanner emulator..."
-	@docker run -d --name $(DOCKER_CONTAINER_NAME) -p $(DOCKER_PORT):9010 $(DOCKER_IMAGE) || \
-		(docker start $(DOCKER_CONTAINER_NAME) && echo "✅ Emulator already running")
+start: ## Start Spanner emulator (with fresh state)
+	@echo "🐳 Starting fresh Spanner emulator..."
+	@docker stop $(DOCKER_CONTAINER_NAME) 2>/dev/null || true
+	@docker rm $(DOCKER_CONTAINER_NAME) 2>/dev/null || true
+	@docker run -d --name $(DOCKER_CONTAINER_NAME) -p $(DOCKER_PORT):9010 $(DOCKER_IMAGE)
 	@echo "⏳ Waiting for emulator..."
 	@sleep 10
-	@echo "✅ Spanner emulator ready on localhost:$(DOCKER_PORT)"
+	@echo "✅ Fresh Spanner emulator ready on localhost:$(DOCKER_PORT)"
 
 stop: ## Stop Spanner emulator
 	@echo "🛑 Stopping Spanner emulator..."
@@ -64,21 +65,30 @@ clean: ## Clean up containers and artifacts
 setup: ## Setup databases and schemas
 	@echo "🏗️ Setting up databases..."
 	@$(MAKE) start
+	@$(MAKE) clean-databases
 	@$(MAKE) setup-primary
 ifeq ($(DB_COUNT),2)
 	@$(MAKE) setup-secondary
 endif
 	@echo "✅ Database setup complete"
 
+clean-databases: ## Clean existing databases
+	@echo "🧹 Cleaning existing databases..."
+	@SPANNER_EMULATOR_HOST=localhost:$(DOCKER_PORT) wrench instance create --project $(PROJECT_ID) --instance $(INSTANCE_ID) >/dev/null 2>&1 || true
+	@SPANNER_EMULATOR_HOST=localhost:$(DOCKER_PORT) wrench drop --project $(PROJECT_ID) --instance $(INSTANCE_ID) --database $(PRIMARY_DB_ID) >/dev/null 2>&1 || true
+ifeq ($(DB_COUNT),2)
+	@SPANNER_EMULATOR_HOST=localhost:$(DOCKER_PORT) wrench drop --project $(PROJECT_ID) --instance $(INSTANCE_ID) --database $(SECONDARY_DB_ID) >/dev/null 2>&1 || true
+endif
+
 setup-primary: ## Setup primary database
 	@echo "🔶 Setting up primary database..."
 	@SPANNER_EMULATOR_HOST=localhost:$(DOCKER_PORT) wrench instance create --project $(PROJECT_ID) --instance $(INSTANCE_ID) >/dev/null 2>&1 || true
-	@SPANNER_EMULATOR_HOST=localhost:$(DOCKER_PORT) wrench create --project $(PROJECT_ID) --instance $(INSTANCE_ID) --database $(PRIMARY_DB_ID) --directory "$$(pwd)/$(PRIMARY_DB_SCHEMA_PATH)" || true
+	@SPANNER_EMULATOR_HOST=localhost:$(DOCKER_PORT) wrench create --project $(PROJECT_ID) --instance $(INSTANCE_ID) --database $(PRIMARY_DB_ID) --directory "$$(pwd)/$(PRIMARY_DB_SCHEMA_PATH)" >/dev/null 2>&1 || true
 	@go run cmd/seed-injector/main.go --database-id $(PRIMARY_DB_ID) --fixture-dir scenarios/$(SCENARIO)/fixtures/primary
 
 setup-secondary: ## Setup secondary database
 	@echo "☁️ Setting up secondary database..."
-	@SPANNER_EMULATOR_HOST=localhost:$(DOCKER_PORT) wrench create --project $(PROJECT_ID) --instance $(INSTANCE_ID) --database $(SECONDARY_DB_ID) --directory "$$(pwd)/$(SECONDARY_DB_SCHEMA_PATH)" || true
+	@SPANNER_EMULATOR_HOST=localhost:$(DOCKER_PORT) wrench create --project $(PROJECT_ID) --instance $(INSTANCE_ID) --database $(SECONDARY_DB_ID) --directory "$$(pwd)/$(SECONDARY_DB_SCHEMA_PATH)" >/dev/null 2>&1 || true
 	@go run cmd/seed-injector/main.go --database-id $(SECONDARY_DB_ID) --fixture-dir scenarios/$(SCENARIO)/fixtures/secondary
 
 test-scenario: ## Run specific scenario test
@@ -93,9 +103,13 @@ run-all-scenarios: ## Run all scenarios
 	@$(MAKE) setup
 	@for scenario in $$(ls scenarios/ | grep -E '^(scenario|example)-'); do \
 		echo "▶️ Running $$scenario"; \
-		SCENARIO=$$scenario $(MAKE) test-scenario || exit 1; \
+		SCENARIO=$$scenario $(MAKE) test-scenario-only || exit 1; \
 	done
 	@echo "✅ All scenarios completed"
+
+test-scenario-only: ## Run specific scenario test without setup
+	@echo "🧪 Running scenario: $(SCENARIO)"
+	@npx playwright test --grep $(SCENARIO)
 
 test-e2e: ## Run Playwright E2E tests
 	@npx playwright test

--- a/examples/two-databases/scenarios/scenario-01-basic-setup/tests/simple-test.spec.ts
+++ b/examples/two-databases/scenarios/scenario-01-basic-setup/tests/simple-test.spec.ts
@@ -9,12 +9,9 @@ test.describe('Simple Basic Test', () => {
     const dbConfig = getDatabaseConfig();
     console.log(`🔧 Process ${dbConfig.processId}: Using databases ${dbConfig.primaryDbId}, ${dbConfig.secondaryDbId}`);
     
-    try {
-      runMake('setup');
-      console.log('✅ Database setup complete');
-    } catch (error) {
-      console.log('⚠️ Database setup failed, continuing with test...');
-    }
+    // Database setup is already handled by Makefile
+    // No need to run setup here - it would cause container conflicts
+    console.log('✅ Using existing database setup from Makefile');
   });
 
   test('Basic Page Test', async ({ page }) => {

--- a/examples/two-databases/scenarios/scenario-01-basic-setup/tests/simple-test.spec.ts
+++ b/examples/two-databases/scenarios/scenario-01-basic-setup/tests/simple-test.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { getDatabaseConfig } from '../../../tests/database-isolation';
-import { runMake, mockValidateDatabase } from '../../../tests/test-utils';
+import {  mockValidateDatabase } from '../../../tests/test-utils';
 
 test.describe('Simple Basic Test', () => {
   test.beforeAll(async () => {

--- a/examples/two-databases/tests/global-setup.ts
+++ b/examples/two-databases/tests/global-setup.ts
@@ -1,25 +1,28 @@
-import { runMake } from './test-utils';
-
 /**
  * Simplified global setup for Playwright tests
- * Only starts the Spanner emulator - database isolation is handled per-test
+ * Relies on Makefile to manage the Spanner emulator setup
  */
 async function globalSetup() {
   console.log('🚀 Starting global test setup...');
   
   try {
-    // Ensure Spanner emulator is running
-    console.log('📡 Starting Spanner emulator...');
-    runMake('start');
+    // The emulator should already be running from Makefile setup
+    // Just verify everything is accessible
+    console.log('🔍 Verifying emulator and tools are accessible...');
     
-    // Give emulator time to fully start
-    console.log('⏳ Waiting for emulator to stabilize...');
-    await new Promise(resolve => setTimeout(resolve, 3000));
+    // Basic verification without starting anything
+    const emulatorHost = process.env.SPANNER_EMULATOR_HOST || 'localhost:9010';
+    console.log(`📡 Expected emulator at: ${emulatorHost}`);
+    
+    // Give a moment for any existing setup to complete
+    console.log('⏳ Waiting for setup to stabilize...');
+    await new Promise(resolve => setTimeout(resolve, 2000));
     
     console.log('✅ Global setup completed successfully');
     
   } catch (error: any) {
     console.error('❌ Global setup failed:', error.message);
+    console.error('🔧 Emulator should be managed by Makefile');
     throw error;
   }
 }


### PR DESCRIPTION
## Summary
- Resolve Docker container name conflicts when running `make run-all-scenarios` repeatedly
- Fix "Database already exists" errors by adding proper cleanup steps
- Optimize test execution flow to avoid redundant setup calls

## Changes Made
- **Makefile `start` command**: Force remove existing containers before starting fresh emulator
- **New `clean-databases` command**: Drop existing databases before recreation
- **`global-setup.ts`**: Remove duplicate emulator start, rely on Makefile management  
- **`run-all-scenarios`**: Use `test-scenario-only` to avoid redundant setup per scenario
- **Error handling**: Improve output suppression and error recovery

## Test Plan
- [x] Run `make run-all-scenarios` multiple times without errors
- [x] Verify Docker container conflicts are resolved
- [x] Confirm database creation errors are eliminated
- [x] Check that all tests pass consistently