### PR TITLE
fix: Add minimal security sanitization for sensitive data in error messages

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -50,15 +50,25 @@ export class SecurityError extends SpanwrightError {
   }
 }
 
+// Sanitize only truly sensitive information from error messages
+export function sanitizeSensitiveInfo(message: string): string {
+  return message
+    .replace(/password[=:]\s*[^\s]+/gi, 'password=***')
+    .replace(/token[=:]\s*[^\s]+/gi, 'token=***')
+    .replace(/api[_-]?key[=:]\s*[^\s]+/gi, 'api_key=***')
+    .replace(/secret[=:]\s*[^\s]+/gi, 'secret=***')
+    .replace(/bearer\s+[^\s]+/gi, 'bearer ***');
+}
+
 // Error handling utility
 export function handleError(error: unknown): never {
   if (error instanceof SpanwrightError) {
-    console.error(error.message);
+    console.error(sanitizeSensitiveInfo(error.message));
     process.exit(1);
   }
 
   if (error instanceof Error) {
-    console.error('❌ An error occurred:', error.message);
+    console.error('❌ An error occurred:', sanitizeSensitiveInfo(error.message));
     process.exit(1);
   }
 


### PR DESCRIPTION
## Summary
Minimal fix for Issue #61 - sanitizes only truly sensitive information in error messages while preserving useful debugging information.

## Previous Approach (Over-engineered)
- 555 lines of changes across 7 files
- Complex error handling framework with environment-based logging
- Removed all file paths and system information
- Poor developer experience due to lack of debugging information

## New Approach (Minimal & Practical)
- **15 lines of code** - simple and maintainable
- Only masks truly sensitive data: passwords, tokens, API keys, secrets, bearer tokens
- Preserves file paths, stack traces, and system info for debugging
- Better developer experience while still protecting sensitive information

## Implementation
```typescript
export function sanitizeSensitiveInfo(message: string): string {
  return message
    .replace(/password[=:]\s*[^\s]+/gi, 'password=***')
    .replace(/token[=:]\s*[^\s]+/gi, 'token=***')
    .replace(/api[_-]?key[=:]\s*[^\s]+/gi, 'api_key=***')
    .replace(/secret[=:]\s*[^\s]+/gi, 'secret=***')
    .replace(/bearer\s+[^\s]+/gi, 'bearer ***');
}
```

## Examples
- ❌ Before: `Failed to connect: password=mysecretpass123`
- ✅ After: `Failed to connect: password=***`

- ✅ File paths preserved: `Failed to read file: /Users/dev/project/config.json`
- ✅ Stack traces preserved for debugging

## Rationale
As a development tool (template generator), detailed error messages are more valuable than hiding non-sensitive information. This approach provides the right balance between security and usability.

Fixes #61