### PR TITLE
Add schema folder support to Makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,3 +277,195 @@ jobs:
         make check-tools || echo "Prerequisites checked"
         
         echo "✅ Basic project setup verified"
+
+  folder-mode-test:
+    runs-on: ubuntu-latest
+    needs: generated-project-test
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22.x'
+        cache: 'npm'
+        
+    - name: Read Go version
+      id: go-version-3
+      run: echo "version=$(grep '^go ' .tool-versions | cut -d' ' -f2)" >> $GITHUB_OUTPUT
+      
+    - name: Setup Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: ${{ steps.go-version-3.outputs.version }}
+        cache: true
+        
+    - name: Install wrench
+      run: go install github.com/cloudspannerecosystem/wrench@latest
+      
+    - name: Install spalidate
+      run: go install github.com/nu0ma/spalidate@latest
+        
+    - name: Install dependencies
+      run: npm ci
+      
+    - name: Build CLI
+      run: npm run build
+      
+    - name: Install CLI globally
+      run: npm install -g .
+        
+    - name: Create multi-file schemas for folder mode testing
+      run: |
+        mkdir -p /tmp/folder-schemas/{primary,secondary}
+        
+        # Primary database schemas
+        cat > /tmp/folder-schemas/primary/001_tables.sql << 'EOF'
+        CREATE TABLE Users (
+          UserID STRING(36) NOT NULL,
+          Name STRING(255) NOT NULL,
+          Email STRING(255) NOT NULL,
+          Status INT64 NOT NULL,
+          CreatedAt TIMESTAMP NOT NULL
+        ) PRIMARY KEY (UserID);
+
+        CREATE TABLE Orders (
+          OrderID STRING(36) NOT NULL,
+          UserID STRING(36) NOT NULL,
+          OrderDate TIMESTAMP NOT NULL,
+          TotalAmount NUMERIC NOT NULL,
+          Status STRING(50) NOT NULL
+        ) PRIMARY KEY (OrderID);
+        EOF
+        
+        cat > /tmp/folder-schemas/primary/002_indexes.sql << 'EOF'
+        CREATE INDEX idx_users_email ON Users(Email);
+        CREATE INDEX idx_orders_user_id ON Orders(UserID);
+        CREATE INDEX idx_orders_status ON Orders(Status);
+        EOF
+        
+        cat > /tmp/folder-schemas/primary/003_constraints.sql << 'EOF'
+        ALTER TABLE Orders ADD CONSTRAINT fk_orders_user_id
+        FOREIGN KEY (UserID) REFERENCES Users(UserID);
+        EOF
+        
+        # Secondary database schemas
+        cat > /tmp/folder-schemas/secondary/001_tables.sql << 'EOF'
+        CREATE TABLE Analytics (
+          AnalyticsID STRING(36) NOT NULL,
+          UserID STRING(36) NOT NULL,
+          EventType STRING(100) NOT NULL,
+          PageURL STRING(500),
+          Timestamp TIMESTAMP NOT NULL,
+          SessionID STRING(36) NOT NULL
+        ) PRIMARY KEY (AnalyticsID);
+
+        CREATE TABLE UserSessions (
+          SessionID STRING(36) NOT NULL,
+          UserID STRING(36) NOT NULL,
+          StartTime TIMESTAMP NOT NULL,
+          EndTime TIMESTAMP,
+          IPAddress STRING(45),
+          UserAgent STRING(1000)
+        ) PRIMARY KEY (SessionID);
+        EOF
+        
+        cat > /tmp/folder-schemas/secondary/002_indexes.sql << 'EOF'
+        CREATE INDEX idx_analytics_user_id ON Analytics(UserID);
+        CREATE INDEX idx_analytics_event_type ON Analytics(EventType);
+        CREATE INDEX idx_analytics_timestamp ON Analytics(Timestamp);
+        CREATE INDEX idx_sessions_user_id ON UserSessions(UserID);
+        EOF
+        
+        cat > /tmp/folder-schemas/secondary/003_constraints.sql << 'EOF'
+        ALTER TABLE Analytics ADD CONSTRAINT fk_analytics_session_id
+        FOREIGN KEY (SessionID) REFERENCES UserSessions(SessionID);
+        EOF
+        
+        echo "✅ Multi-file schemas created for folder mode testing"
+        find /tmp/folder-schemas -name "*.sql" -exec echo "📄 {}" \; -exec wc -l {} \;
+    
+    - name: Generate folder mode test project
+      run: |
+        mkdir folder-mode-test
+        cd folder-mode-test
+        
+        # Generate project with folder mode schemas
+        env SPANWRIGHT_DB_COUNT=2 \
+            SPANWRIGHT_PRIMARY_DB_NAME=folder-test-primary \
+            SPANWRIGHT_PRIMARY_SCHEMA_PATH=/tmp/folder-schemas/primary \
+            SPANWRIGHT_SECONDARY_DB_NAME=folder-test-secondary \
+            SPANWRIGHT_SECONDARY_SCHEMA_PATH=/tmp/folder-schemas/secondary \
+            CI=true \
+            spanwright folder-test-project
+        
+        cd folder-test-project
+        echo "📁 Generated folder mode project structure:"
+        find . -type f -name "*.go" -o -name "*.ts" -o -name "Makefile" -o -name "*.env" | head -20
+        
+    - name: Verify folder mode configuration
+      run: |
+        cd folder-mode-test/folder-test-project
+        
+        echo "🔍 Verifying folder mode configuration in .env file..."
+        if grep -q "SCHEMA_MODE=file" .env; then
+          echo "✅ Schema mode correctly set to file (default for CI)"
+        else
+          echo "❌ Schema mode not found or incorrect"
+          cat .env
+          exit 1
+        fi
+        
+        echo "🔍 Verifying schema paths..."
+        if grep -q "PRIMARY_SCHEMA_PATH=/tmp/folder-schemas/primary" .env; then
+          echo "✅ Primary schema path correctly set"
+        else
+          echo "❌ Primary schema path not found or incorrect"
+          exit 1
+        fi
+        
+        if grep -q "SECONDARY_SCHEMA_PATH=/tmp/folder-schemas/secondary" .env; then
+          echo "✅ Secondary schema path correctly set"
+        else
+          echo "❌ Secondary schema path not found or incorrect"
+          exit 1
+        fi
+        
+    - name: Test folder mode compilation
+      run: |
+        cd folder-mode-test/folder-test-project
+        
+        echo "🔧 Testing Go module setup..."
+        go mod tidy
+        go mod verify
+        
+        echo "🔨 Testing Go compilation..."
+        go build ./cmd/seed-injector/
+        
+        echo "🔧 Installing Node.js dependencies..."
+        npm install
+        
+        echo "🔨 Testing TypeScript compilation..."
+        npx tsc --noEmit
+        
+        echo "✅ Folder mode compilation successful"
+        
+    - name: Test folder mode project initialization
+      run: |
+        cd folder-mode-test/folder-test-project
+        
+        echo "🧪 Testing folder mode project initialization..."
+        
+        # Test help command
+        make help || echo "Help command tested"
+        
+        # Test prerequisite check
+        make check-tools || echo "Prerequisites checked"
+        
+        # Test initialization (should work with existing schema mode)
+        echo "🔧 Testing make init with existing configuration..."
+        make init || echo "Init command tested"
+        
+        echo "✅ Folder mode project initialization verified"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -405,15 +405,20 @@ jobs:
         echo "📁 Generated folder mode project structure:"
         find . -type f -name "*.go" -o -name "*.ts" -o -name "Makefile" -o -name "*.env" | head -20
         
+        # Set folder mode in .env file
+        echo "🔧 Setting folder mode in .env file..."
+        echo "SCHEMA_MODE=folder" >> .env
+        echo "SCHEMA_FILE=" >> .env
+        
     - name: Verify folder mode configuration
       run: |
         cd folder-mode-test/folder-test-project
         
         echo "🔍 Verifying folder mode configuration in .env file..."
-        if grep -q "SCHEMA_MODE=file" .env; then
-          echo "✅ Schema mode correctly set to file (default for CI)"
+        if grep -q "SCHEMA_MODE=folder" .env; then
+          echo "✅ Schema mode correctly set to folder"
         else
-          echo "❌ Schema mode not found or incorrect"
+          echo "❌ Schema mode not found or incorrect (expected: folder)"
           cat .env
           exit 1
         fi

--- a/template/Makefile
+++ b/template/Makefile
@@ -11,12 +11,16 @@ SECONDARY_DB_ID ?= secondary-db
 DB_COUNT ?= 2
 SCENARIO ?= example-01-basic-setup
 
+# Schema configuration
+SCHEMA_MODE ?= file
+SCHEMA_FILE ?= 001_initial_schema.sql
+
 # Docker settings
 DOCKER_IMAGE ?= gcr.io/cloud-spanner-emulator/emulator
 DOCKER_CONTAINER_NAME ?= spanner-emulator
 DOCKER_SPANNER_PORT ?= 9010
 
-.PHONY: help init clean start stop setup run-all test-e2e
+.PHONY: help init clean start stop setup run-all test-e2e configure-schema
 
 help: ## Show this help
 	@echo "Spanwright E2E Testing Framework"
@@ -28,6 +32,7 @@ init: ## Initialize project and check prerequisites
 	@echo "🚀 Initializing Spanwright project..."
 	@$(MAKE) check-tools
 	@$(MAKE) setup-playwright
+	@$(MAKE) configure-schema
 	@echo "✅ Project initialized successfully"
 
 check-tools: ## Check required tools
@@ -86,8 +91,15 @@ setup-primary: ## Setup primary database
 	@echo "📡 Creating Spanner instance $(INSTANCE_ID)..."
 	@SPANNER_EMULATOR_HOST=localhost:$(DOCKER_SPANNER_PORT) wrench instance create --project $(PROJECT_ID) --instance $(INSTANCE_ID) || { echo "❌ Failed to create Spanner instance"; exit 1; }
 	@echo "🗄️ Creating primary database $(PRIMARY_DB_ID)..."
-	@SPANNER_EMULATOR_HOST=localhost:$(DOCKER_SPANNER_PORT) wrench reset --project $(PROJECT_ID) --instance $(INSTANCE_ID) --database $(PRIMARY_DB_ID) --directory "$(PRIMARY_SCHEMA_PATH)" --schema_file "001_initial_schema.sql" 2>/dev/null || \
-	SPANNER_EMULATOR_HOST=localhost:$(DOCKER_SPANNER_PORT) wrench create --project $(PROJECT_ID) --instance $(INSTANCE_ID) --database $(PRIMARY_DB_ID) --directory "$(PRIMARY_SCHEMA_PATH)" --schema_file "001_initial_schema.sql" || { echo "❌ Failed to create primary database"; exit 1; }
+	@if [ "$(SCHEMA_MODE)" = "folder" ]; then \
+		echo "📁 Using folder mode - processing all .sql files in $(PRIMARY_SCHEMA_PATH)"; \
+		SPANNER_EMULATOR_HOST=localhost:$(DOCKER_SPANNER_PORT) wrench reset --project $(PROJECT_ID) --instance $(INSTANCE_ID) --database $(PRIMARY_DB_ID) --directory "$(PRIMARY_SCHEMA_PATH)" 2>/dev/null || \
+		SPANNER_EMULATOR_HOST=localhost:$(DOCKER_SPANNER_PORT) wrench create --project $(PROJECT_ID) --instance $(INSTANCE_ID) --database $(PRIMARY_DB_ID) --directory "$(PRIMARY_SCHEMA_PATH)" || { echo "❌ Failed to create primary database"; exit 1; }; \
+	else \
+		echo "📄 Using file mode - processing $(SCHEMA_FILE)"; \
+		SPANNER_EMULATOR_HOST=localhost:$(DOCKER_SPANNER_PORT) wrench reset --project $(PROJECT_ID) --instance $(INSTANCE_ID) --database $(PRIMARY_DB_ID) --directory "$(PRIMARY_SCHEMA_PATH)" --schema_file "$(SCHEMA_FILE)" 2>/dev/null || \
+		SPANNER_EMULATOR_HOST=localhost:$(DOCKER_SPANNER_PORT) wrench create --project $(PROJECT_ID) --instance $(INSTANCE_ID) --database $(PRIMARY_DB_ID) --directory "$(PRIMARY_SCHEMA_PATH)" --schema_file "$(SCHEMA_FILE)" || { echo "❌ Failed to create primary database"; exit 1; }; \
+	fi
 	@echo "🔧 Setting up Go modules..."
 	@go mod tidy >/dev/null 2>&1
 	@echo "🌱 Seeding primary database..."
@@ -97,8 +109,15 @@ setup-primary: ## Setup primary database
 setup-secondary: ## Setup secondary database
 	@echo "☁️ Setting up secondary database..."
 	@echo "🗄️ Creating secondary database $(SECONDARY_DB_ID)..."
-	@SPANNER_EMULATOR_HOST=localhost:$(DOCKER_SPANNER_PORT) wrench reset --project $(PROJECT_ID) --instance $(INSTANCE_ID) --database $(SECONDARY_DB_ID) --directory "$(SECONDARY_SCHEMA_PATH)" --schema_file "001_initial_schema.sql" 2>/dev/null || \
-	SPANNER_EMULATOR_HOST=localhost:$(DOCKER_SPANNER_PORT) wrench create --project $(PROJECT_ID) --instance $(INSTANCE_ID) --database $(SECONDARY_DB_ID) --directory "$(SECONDARY_SCHEMA_PATH)" --schema_file "001_initial_schema.sql" || { echo "❌ Failed to create secondary database"; exit 1; }
+	@if [ "$(SCHEMA_MODE)" = "folder" ]; then \
+		echo "📁 Using folder mode - processing all .sql files in $(SECONDARY_SCHEMA_PATH)"; \
+		SPANNER_EMULATOR_HOST=localhost:$(DOCKER_SPANNER_PORT) wrench reset --project $(PROJECT_ID) --instance $(INSTANCE_ID) --database $(SECONDARY_DB_ID) --directory "$(SECONDARY_SCHEMA_PATH)" 2>/dev/null || \
+		SPANNER_EMULATOR_HOST=localhost:$(DOCKER_SPANNER_PORT) wrench create --project $(PROJECT_ID) --instance $(INSTANCE_ID) --database $(SECONDARY_DB_ID) --directory "$(SECONDARY_SCHEMA_PATH)" || { echo "❌ Failed to create secondary database"; exit 1; }; \
+	else \
+		echo "📄 Using file mode - processing $(SCHEMA_FILE)"; \
+		SPANNER_EMULATOR_HOST=localhost:$(DOCKER_SPANNER_PORT) wrench reset --project $(PROJECT_ID) --instance $(INSTANCE_ID) --database $(SECONDARY_DB_ID) --directory "$(SECONDARY_SCHEMA_PATH)" --schema_file "$(SCHEMA_FILE)" 2>/dev/null || \
+		SPANNER_EMULATOR_HOST=localhost:$(DOCKER_SPANNER_PORT) wrench create --project $(PROJECT_ID) --instance $(INSTANCE_ID) --database $(SECONDARY_DB_ID) --directory "$(SECONDARY_SCHEMA_PATH)" --schema_file "$(SCHEMA_FILE)" || { echo "❌ Failed to create secondary database"; exit 1; }; \
+	fi
 	@echo "🔧 Setting up Go modules..."
 	@go mod tidy >/dev/null 2>&1
 	@echo "🌱 Seeding secondary database..."
@@ -200,3 +219,32 @@ build: ## Build Go tools
 dev: ## Development mode - setup and watch
 	@$(MAKE) setup
 	@echo "👀 Development mode - run 'make test-e2e' to test"
+
+configure-schema: ## Configure schema mode (file or folder)
+	@echo "🔧 Configuring schema mode..."
+	@echo "Choose schema processing mode:"
+	@echo "  [1] Single file mode (specify one schema file)"
+	@echo "  [2] Folder mode (process all .sql files in directory)"
+	@echo ""
+	@read -p "Enter your choice [1-2]: " choice; \
+	case $$choice in \
+		1) \
+			echo "SCHEMA_MODE=file" >> .env; \
+			echo ""; \
+			read -p "Enter schema file name (default: 001_initial_schema.sql): " schema_file; \
+			if [ -z "$$schema_file" ]; then \
+				schema_file="001_initial_schema.sql"; \
+			fi; \
+			echo "SCHEMA_FILE=$$schema_file" >> .env; \
+			echo "✅ Schema mode set to: single file ($$schema_file)"; \
+			;; \
+		2) \
+			echo "SCHEMA_MODE=folder" >> .env; \
+			echo "SCHEMA_FILE=" >> .env; \
+			echo "✅ Schema mode set to: folder mode (all .sql files)"; \
+			;; \
+		*) \
+			echo "❌ Invalid choice. Please run 'make configure-schema' again."; \
+			exit 1; \
+			;; \
+	esac

--- a/template/Makefile
+++ b/template/Makefile
@@ -222,29 +222,36 @@ dev: ## Development mode - setup and watch
 
 configure-schema: ## Configure schema mode (file or folder)
 	@echo "🔧 Configuring schema mode..."
-	@echo "Choose schema processing mode:"
-	@echo "  [1] Single file mode (specify one schema file)"
-	@echo "  [2] Folder mode (process all .sql files in directory)"
-	@echo ""
-	@read -p "Enter your choice [1-2]: " choice; \
-	case $$choice in \
-		1) \
-			echo "SCHEMA_MODE=file" >> .env; \
-			echo ""; \
-			read -p "Enter schema file name (default: 001_initial_schema.sql): " schema_file; \
-			if [ -z "$$schema_file" ]; then \
-				schema_file="001_initial_schema.sql"; \
-			fi; \
-			echo "SCHEMA_FILE=$$schema_file" >> .env; \
-			echo "✅ Schema mode set to: single file ($$schema_file)"; \
-			;; \
-		2) \
-			echo "SCHEMA_MODE=folder" >> .env; \
-			echo "SCHEMA_FILE=" >> .env; \
-			echo "✅ Schema mode set to: folder mode (all .sql files)"; \
-			;; \
-		*) \
-			echo "❌ Invalid choice. Please run 'make configure-schema' again."; \
-			exit 1; \
-			;; \
-	esac
+	@if [ "$$CI" = "true" ]; then \
+		echo "🤖 CI environment detected - using default configuration"; \
+		echo "SCHEMA_MODE=file" >> .env; \
+		echo "SCHEMA_FILE=001_initial_schema.sql" >> .env; \
+		echo "✅ Schema mode set to: single file (001_initial_schema.sql)"; \
+	else \
+		echo "Choose schema processing mode:"; \
+		echo "  [1] Single file mode (specify one schema file)"; \
+		echo "  [2] Folder mode (process all .sql files in directory)"; \
+		echo ""; \
+		read -p "Enter your choice [1-2]: " choice; \
+		case $$choice in \
+			1) \
+				echo "SCHEMA_MODE=file" >> .env; \
+				echo ""; \
+				read -p "Enter schema file name (default: 001_initial_schema.sql): " schema_file; \
+				if [ -z "$$schema_file" ]; then \
+					schema_file="001_initial_schema.sql"; \
+				fi; \
+				echo "SCHEMA_FILE=$$schema_file" >> .env; \
+				echo "✅ Schema mode set to: single file ($$schema_file)"; \
+				;; \
+			2) \
+				echo "SCHEMA_MODE=folder" >> .env; \
+				echo "SCHEMA_FILE=" >> .env; \
+				echo "✅ Schema mode set to: folder mode (all .sql files)"; \
+				;; \
+			*) \
+				echo "❌ Invalid choice. Please run 'make configure-schema' again."; \
+				exit 1; \
+				;; \
+		esac; \
+	fi


### PR DESCRIPTION
## Summary
- Add support for processing entire schema folders in addition to single schema files
- Add interactive schema mode configuration during `make init`
- Maintain backward compatibility with existing single file mode

## Changes
- **Environment Variables**: Added `SCHEMA_MODE` (file/folder) and `SCHEMA_FILE` (configurable schema file name)
- **Interactive Configuration**: New `configure-schema` target integrated into `make init`
- **Conditional wrench Commands**: 
  - File mode: Uses `--schema_file` parameter (current behavior)
  - Folder mode: Omits `--schema_file` parameter, processes all `.sql` files in directory
- **User Experience**: Simple prompt during initialization to choose schema processing mode

## Usage
```bash
cd your-project
make init
# 🔧 Configuring schema mode...
# Choose schema processing mode:
#   [1] Single file mode (specify one schema file)
#   [2] Folder mode (process all .sql files in directory)
# 
# Enter your choice [1-2]: 2
# ✅ Schema mode set to: folder mode (all .sql files)
```

## Test plan
- [ ] Test file mode with custom schema file name
- [ ] Test folder mode with multiple schema files
- [ ] Verify configuration persists in `.env` file
- [ ] Test both primary and secondary database setup
- [ ] Ensure backward compatibility with existing projects