### PR TITLE
fix: correct scenario directory name in validation tests

### DIFF
--- a/examples/two-databases/scenarios/example-01-basic-setup/tests/simple-test.spec.ts
+++ b/examples/two-databases/scenarios/example-01-basic-setup/tests/simple-test.spec.ts
@@ -27,10 +27,10 @@ test.describe('Simple Basic Test', () => {
     const dbConfig = getDatabaseConfig();
 
     // Use the environment variable database IDs instead of process-specific ones
-    const validation1 = validateDatabaseState('scenario-01-basic-setup', 'primary');
+    const validation1 = validateDatabaseState('example-01-basic-setup', 'primary');
     expect(validation1).toBe(true);
 
-    const validation2 = validateDatabaseState('scenario-01-basic-setup', 'secondary');
+    const validation2 = validateDatabaseState('example-01-basic-setup', 'secondary');
     expect(validation2).toBe(true);
 
     console.log(`✅ Database validation passed for process ${dbConfig.processId}`);


### PR DESCRIPTION
## Summary
- Fixed scenario name mismatch in validation tests
- Changed 'scenario-01-basic-setup' to 'example-01-basic-setup' to match actual directory name
- Ensures validation YAML files are correctly found during test execution

## Test plan
- [ ] Run `npm test` to verify validation works correctly
- [ ] Check that validation files (expected-primary.yaml, expected-secondary.yaml) are properly loaded
- [ ] Confirm no "No validation file found" warnings appear during test execution