### PR TITLE
docs: fix environment variable table syntax

### DIFF
--- a/docs/api/cli-commands.md
+++ b/docs/api/cli-commands.md
@@ -32,7 +32,7 @@ npx spanwright my-project --non-interactive
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `SPANWRIGHT_DB_COUNT=1) | `1` |
+| `SPANWRIGHT_DB_COUNT` | Number of databases (1 or 2) | `1` |
 | `SPANWRIGHT_PRIMARY_DB_NAME` | Primary database name | `primary-db` |
 | `SPANWRIGHT_PRIMARY_SCHEMA_PATH` | Path to primary schema files | `./schema` |
 | `SPANWRIGHT_SECONDARY_DB_NAME` | Secondary database name | `secondary-db` |


### PR DESCRIPTION
## Summary
- Fixed syntax error in environment variable table in `docs/api/cli-commands.md`
- Corrected malformed table entry `SPANWRIGHT_DB_COUNT=1)` to proper format
- Added missing description column for better documentation clarity

## Changes
- Line 35: Fixed table syntax error and added proper description

This was discovered during a comprehensive documentation fact-check process.