### PR TITLE
feat: simplify validateDatabaseState by removing scenario parameter

### DIFF
--- a/examples/two-databases/scenarios/example-01-basic-setup/tests/simple-test.spec.ts
+++ b/examples/two-databases/scenarios/example-01-basic-setup/tests/simple-test.spec.ts
@@ -27,10 +27,10 @@ test.describe('Simple Basic Test', () => {
     const dbConfig = getDatabaseConfig();
 
     // Use the environment variable database IDs instead of process-specific ones
-    const validation1 = validateDatabaseState('example-01-basic-setup', 'primary');
+    const validation1 = validateDatabaseState('primary');
     expect(validation1).toBe(true);
 
-    const validation2 = validateDatabaseState('example-01-basic-setup', 'secondary');
+    const validation2 = validateDatabaseState('secondary');
     expect(validation2).toBe(true);
 
     console.log(`✅ Database validation passed for process ${dbConfig.processId}`);

--- a/examples/two-databases/scenarios/example-01-basic-setup/tests/simple-test.spec.ts
+++ b/examples/two-databases/scenarios/example-01-basic-setup/tests/simple-test.spec.ts
@@ -25,7 +25,7 @@ test.describe('Simple Basic Test', () => {
     const validation1 = validateDatabaseState('example-01-basic-setup', 'primary');
     expect(validation1).toBe(true);
 
-    const validation2 = validateDatabaseState("example-01-basic-setup",'secondary');
+    const validation2 = validateDatabaseState('example-01-basic-setup', 'secondary');
     expect(validation2).toBe(true);
 
     console.log(`✅ Database validation passed for process ${dbConfig.processId}`);

--- a/examples/two-databases/scenarios/example-01-basic-setup/tests/simple-test.spec.ts
+++ b/examples/two-databases/scenarios/example-01-basic-setup/tests/simple-test.spec.ts
@@ -25,7 +25,7 @@ test.describe('Simple Basic Test', () => {
     const validation1 = validateDatabaseState('example-01-basic-setup', 'primary');
     expect(validation1).toBe(true);
 
-    const validation2 = validateDatabaseState('secondary');
+    const validation2 = validateDatabaseState("example-01-basic-setup",'secondary');
     expect(validation2).toBe(true);
 
     console.log(`✅ Database validation passed for process ${dbConfig.processId}`);

--- a/template/scenarios/example-01-basic-setup/tests/simple-test.spec.ts
+++ b/template/scenarios/example-01-basic-setup/tests/simple-test.spec.ts
@@ -11,12 +11,12 @@ test.describe('example-01-basic-setup', () => {
   test('Database Validation', async () => {
     const dbConfig = getDatabaseConfig();
     
-    const primaryValid = validateDatabaseState('example-01-basic-setup', 'primary', dbConfig.primaryDbId);
+    const primaryValid = validateDatabaseState('primary', dbConfig.primaryDbId);
     expect(primaryValid).toBe(true);
     
     const dbCount = parseInt(process.env.DB_COUNT || '2');
     if (dbCount === 2) {
-      const secondaryValid = validateDatabaseState('example-01-basic-setup', 'secondary', dbConfig.secondaryDbId);
+      const secondaryValid = validateDatabaseState('secondary', dbConfig.secondaryDbId);
       expect(secondaryValid).toBe(true);
     }
   });

--- a/template/scenarios/scenario-02-intermediate/tests/intermediate-test.spec.ts
+++ b/template/scenarios/scenario-02-intermediate/tests/intermediate-test.spec.ts
@@ -12,12 +12,12 @@ test.describe('scenario-02-intermediate', () => {
   test('Advanced Database Validation', async () => {
     const dbConfig = getDatabaseConfig();
     
-    const primaryValid = validateDatabaseState('scenario-02-intermediate', 'primary', dbConfig.primaryDbId);
+    const primaryValid = validateDatabaseState('primary', dbConfig.primaryDbId);
     expect(primaryValid).toBe(true);
     
     const dbCount = parseInt(process.env.DB_COUNT || '2');
     if (dbCount === 2) {
-      const secondaryValid = validateDatabaseState('scenario-02-intermediate', 'secondary', dbConfig.secondaryDbId);
+      const secondaryValid = validateDatabaseState('secondary', dbConfig.secondaryDbId);
       expect(secondaryValid).toBe(true);
     }
   });

--- a/template/scenarios/scenario-03-advanced/tests/advanced-test.spec.ts
+++ b/template/scenarios/scenario-03-advanced/tests/advanced-test.spec.ts
@@ -15,12 +15,12 @@ test.describe('scenario-03-advanced', () => {
   test('Comprehensive Database Validation', async () => {
     const dbConfig = getDatabaseConfig();
     
-    const primaryValid = validateDatabaseState('scenario-03-advanced', 'primary', dbConfig.primaryDbId);
+    const primaryValid = validateDatabaseState('primary', dbConfig.primaryDbId);
     expect(primaryValid).toBe(true);
     
     const dbCount = parseInt(process.env.DB_COUNT || '2');
     if (dbCount === 2) {
-      const secondaryValid = validateDatabaseState('scenario-03-advanced', 'secondary', dbConfig.secondaryDbId);
+      const secondaryValid = validateDatabaseState('secondary', dbConfig.secondaryDbId);
       expect(secondaryValid).toBe(true);
     }
   });

--- a/template/tests/test-utils.ts
+++ b/template/tests/test-utils.ts
@@ -51,8 +51,8 @@ export function mockValidateDatabase(databaseId: string): ValidationResult[] {
 }
 
 // Real spalidate validation
-export function validateDatabaseState(scenario: string, database: 'primary' | 'secondary', databaseId?: string): boolean {
-  const validationFile = path.join(process.cwd(), 'scenarios', scenario, `expected-${database}.yaml`);
+export function validateDatabaseState(database: 'primary' | 'secondary', databaseId?: string): boolean {
+  const validationFile = path.join(process.cwd(), `expected-${database}.yaml`);
   const config   = {
     projectId: process.env.PROJECT_ID || 'test-project',
     instanceId: process.env.INSTANCE_ID || 'test-instance',


### PR DESCRIPTION
## Summary
- Remove scenario parameter from `validateDatabaseState` function
- Auto-detect expected YAML files from current working directory
- Update all test files to use simplified function signature

## Test plan
- [x] All E2E tests pass with `npm test`
- [x] Database validation works correctly in all scenarios
- [x] Function correctly finds expected-*.yaml files in current directory