### PR TITLE
fix: correct target_commitish to main in release workflow

### DIFF
--- a/.github/workflows/create_release_pr.yml
+++ b/.github/workflows/create_release_pr.yml
@@ -55,7 +55,7 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             /repos/${{ github.repository }}/releases/generate-notes \
             -f tag_name="v${{ env.VERSION }}" \
-            -f target_commitish="master" \
+            -f target_commitish="main" \
             -f previous_tag_name="${LAST_TAG}" | jq -r '.body')
           
           # Save to file to handle multiline content


### PR DESCRIPTION
## Summary
- Fix target_commitish from "master" to "main" in create_release_pr.yml
- This ensures PR titles will be "Release v{version}" instead of "chore(main): release {version}"

## Test plan
- [ ] Trigger create_release_pr workflow to verify PR title format