### PR TITLE
fix: remove NPM_TOKEN to enable trusted publishing with OIDC

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,21 +73,12 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
       
-      - name: Ensure npm 10.0.0 or later is installed
+      - name: Ensure npm 11.5.1 or later is installed
         if: steps.tag-check.outputs.exists == 'false'
         run: |
           NPM_VERSION=$(npm -v)
           echo "Current npm version: $NPM_VERSION"
-          REQUIRED_VERSION="10.0.0"
-          if ! node -e "
-            const current = '$NPM_VERSION'.split('.').map(Number);
-            const required = '$REQUIRED_VERSION'.split('.').map(Number);
-            for (let i = 0; i < 3; i++) {
-              if (current[i] > required[i]) process.exit(0);
-              if (current[i] < required[i]) process.exit(1);
-            }
-            process.exit(0);
-          "; then
+          if ! npx semver -r ">=11.5.1" "$NPM_VERSION"; then
             echo "npm version $NPM_VERSION is too old. Installing latest npm..."
             npm install -g npm@latest
             echo "Updated npm version: $(npm -v)"


### PR DESCRIPTION
## Summary
- Remove `NODE_AUTH_TOKEN` environment variable from npm publish step to enable npm trusted publishing with OpenID Connect (OIDC)
- Resolves authentication error: `npm error need auth This command requires you to be logged in`

## Problem
Despite having OpenID Connect (OIDC) trusted publishing configured in npm, the workflow was still using the legacy `NPM_TOKEN` secret, which conflicts with trusted publishing and causes authentication failures.

## Solution
- Remove `NODE_AUTH_TOKEN` environment variable from the npm publish step
- Keep `--provenance` flag for package attestation
- Rely solely on OIDC authentication via the `id-token: write` permission

## Test plan
- [x] Verify workflow file changes
- [ ] Test npm publish with trusted publishing on next release
- [ ] Confirm authentication works without NPM_TOKEN

## References
- [npm trusted publishing documentation](https://docs.npmjs.com/generating-provenance-statements)
- [GitHub OIDC documentation](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect)