### PR TITLE
chore: Allow any types in ESLint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -24,7 +24,7 @@ export default [
       ...js.configs.recommended.rules,
       ...tseslint.configs.recommended.rules,
       '@typescript-eslint/no-unused-vars': 'error',
-      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/explicit-function-return-type': 'off',
       '@typescript-eslint/explicit-module-boundary-types': 'off',
       'no-console': 'off',


### PR DESCRIPTION
## Summary
- Disable `@typescript-eslint/no-explicit-any` rule to allow `any` types without warnings

## Changes
- Set `@typescript-eslint/no-explicit-any` from 'warn' to 'off' in `eslint.config.mjs`