### PR TITLE
Update README with correct Make targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ cd your-project-name
 make init
 
 # Run all test scenarios
-make run-all-scenarios
+make test
 ```
 
 ## Features
@@ -64,23 +64,19 @@ your-project-name/
 
 ```bash
 # Project setup
-make init                       # Install dependencies
+make init                       # Initialize project and install dependencies
 make start                      # Start Spanner emulator
-make setup-all                  # Apply schema migrations
+make setup                      # Setup databases and schemas
 
 # Testing
-make run-all-scenarios         # Run all test scenarios
-make test-e2e                  # Run Playwright tests only
-make list-scenarios            # Show available scenarios
+make test                       # Run complete E2E test workflow
+make test-scenario SCENARIO=name  # Run E2E test for a specific scenario
 
-# Development
-make clean                     # Clean build artifacts
-make help                      # Show all available commands
+# Utilities
+make stop                       # Stop Spanner emulator
+make help                       # Show available commands
 ```
 
-## Contributing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and contribution guidelines.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Update README.md to reflect actual Make targets available in the project
- Fix command references from `run-all-scenarios` to `test`
- Simplify command documentation by removing non-existent targets
- Clean up project setup instructions

## Changes
- Changed `make run-all-scenarios` to `make test` in quick start
- Updated Available Commands section to match actual Makefile
- Removed references to non-existent targets like `test-e2e`, `setup-all`
- Simplified command descriptions for better clarity
- Removed CONTRIBUTING.md reference (file doesn't exist)

## Test plan
- [x] Verified Make targets exist in Makefile
- [x] Confirmed documentation matches implementation