### PR TITLE
fix: remove pnpm onlyBuiltDependencies config

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,11 +51,6 @@
   "bugs": {
     "url": "https://github.com/nu0ma/spanwright/issues"
   },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild"
-    ]
-  },
   "devDependencies": {
     "@types/node": "^24.0.10",
     "@eslint/js": "9.34.0",


### PR DESCRIPTION
## Summary
- Remove pnpm.onlyBuiltDependencies configuration from package.json
- Clean up unnecessary pnpm-specific esbuild configuration

## Test plan
- [x] Build and test locally
- [x] CI tests pass