### PR TITLE
refactor: remove secondary DB pruning and simplify templates

### DIFF
--- a/src/__tests__/file-operations.test.ts
+++ b/src/__tests__/file-operations.test.ts
@@ -13,7 +13,6 @@ import {
   replaceInFile,
   processTemplateFiles,
   replaceProjectNameInGoFiles,
-  removeSecondaryDbFiles,
 } from '../file-operations';
 import { FileSystemError, SecurityError } from '../errors';
 import { FILE_PATTERNS } from '../constants';
@@ -844,58 +843,6 @@ describe('File Operations Module', () => {
         'package my-project',
         'utf8'
       );
-    });
-  });
-
-  describe('removeSecondaryDbFiles', () => {
-    it('should remove secondary database files', () => {
-      const projectPath = '/test/project';
-      mockFs.unlinkSync.mockReturnValue(undefined);
-
-      removeSecondaryDbFiles(projectPath);
-
-      expect(mockFs.unlinkSync).toHaveBeenCalledTimes(3);
-    });
-
-    it('should handle missing files gracefully', () => {
-      const projectPath = '/test/project';
-      const error = new Error('File not found') as any;
-      error.code = 'ENOENT';
-      mockFs.unlinkSync.mockImplementation(() => {
-        throw error;
-      });
-
-      expect(() => removeSecondaryDbFiles(projectPath)).not.toThrow();
-    });
-
-    it('should handle partial file existence', () => {
-      const projectPath = '/test/project';
-
-      // Mock first file to succeed, others to fail with ENOENT
-      let callCount = 0;
-      mockFs.unlinkSync.mockImplementation(() => {
-        callCount++;
-        if (callCount > 1) {
-          const error = new Error('File not found') as any;
-          error.code = 'ENOENT';
-          throw error;
-        }
-      });
-
-      expect(() => removeSecondaryDbFiles(projectPath)).not.toThrow();
-      expect(mockFs.unlinkSync).toHaveBeenCalledTimes(3);
-    });
-
-    it('should throw FileSystemError if file deletion fails', () => {
-      const projectPath = '/test/project';
-
-      mockFs.existsSync.mockReturnValue(true);
-      mockFs.unlinkSync.mockImplementation(() => {
-        throw new Error('Permission denied');
-      });
-
-      expect(() => removeSecondaryDbFiles(projectPath)).toThrow(FileSystemError);
-      expect(() => removeSecondaryDbFiles(projectPath)).toThrow('Failed to delete file:');
     });
   });
 });

--- a/src/commands/spanwright.ts
+++ b/src/commands/spanwright.ts
@@ -10,7 +10,6 @@ import {
   copyDirectory,
   processTemplateFiles,
   replaceProjectNameInGoFiles,
-  removeSecondaryDbFiles,
   writeFileContent,
   renameFixtureDirectories,
 } from '../file-operations'
@@ -118,11 +117,6 @@ $ spanwright --help`,
       const envPath = path.join(projectPath, FILE_PATTERNS.ENV)
       writeFileContent(envPath, envContent)
 
-      // Remove unnecessary files for single DB configuration
-      if (config.count === '1') {
-        logger.info(MESSAGES.INFO.REMOVING_FILES)
-        removeSecondaryDbFiles(projectPath)
-      }
 
       // Show completion message
       logger.log('')

--- a/src/file-operations.ts
+++ b/src/file-operations.ts
@@ -360,22 +360,3 @@ export function replaceProjectNameInGoFiles(projectPath: string, projectName: st
 
   processDirectory(projectPath);
 }
-
-export function removeSecondaryDbFiles(projectPath: string): void {
-  // Only validate relative paths to avoid issues with absolute paths in tests
-  if (!path.isAbsolute(projectPath)) {
-    validatePath(process.cwd(), projectPath, 'removeSecondaryDbFiles');
-  }
-
-  const exampleDir = path.join(projectPath, 'scenarios', 'example-01-basic-setup');
-
-  const filesToRemove = [
-    path.join(exampleDir, 'expected-secondary.yaml'),
-    path.join(exampleDir, 'seed-data', 'secondary-seed.json'),
-    path.join(projectPath, 'expected-secondary.yaml.template'),
-  ];
-
-  for (const file of filesToRemove) {
-    safeFileDelete(file);
-  }
-}

--- a/template/README.md
+++ b/template/README.md
@@ -9,10 +9,8 @@ Cloud Spanner database E2E testing environment
 make init
 
 # Run all scenarios
-make run-all-scenarios
+make test
 
-# Create new test
-make new-scenario SCENARIO=scenario-01-my-test
 ```
 
 ## Main Commands
@@ -20,21 +18,8 @@ make new-scenario SCENARIO=scenario-01-my-test
 | Command | Description |
 |---------|-------------|
 | `make init` | Initial setup |
-| `make run-all-examples` | Alias for run-all-scenarios |
-| `make run-all-scenarios` | Run all scenarios |
-| `make new-scenario SCENARIO=<name>` | Create new scenario |
-| `make test-e2e` | Playwright E2E test |
+| `make test` | Run all scenarios |
 | `make help` | Detailed help |
-
-## Connection Information
-
-Connection information when emulator is running:
-
-```bash
-export SPANNER_EMULATOR_HOST=localhost:9010
-# Project: test-project
-# Instance: test-instance
-```
 
 ## Configuration
 
@@ -44,14 +29,4 @@ Configure database count and schema paths in `.env` file:
 DB_COUNT=2                                    # 1 or 2
 PRIMARY_DB_SCHEMA_PATH=/path/to/schema1       # Required
 SECONDARY_DB_SCHEMA_PATH=/path/to/schema2     # Only for 2DB setup
-```
-
-## Scenario Structure
-
-```
-scenarios/example-01-basic-setup/
-├── expected-primary.yaml          # Expected values for Primary DB
-├── expected-secondary.yaml        # Expected values for Secondary DB (2DB setup)
-├── seed-data/                     # Seed data
-└── tests/                         # Playwright E2E tests
 ```

--- a/template/_package.json
+++ b/template/_package.json
@@ -14,12 +14,8 @@
     "playwright:install": "playwright install chromium"
   },
   "devDependencies": {
-    "@playwright/test": "^1.40.0",
-    "@types/node": "^20.0.0",
-    "typescript": "^5.3.0"
-  },
-  "engines": {
-    "node": ">=16.0.0",
-    "pnpm": ">=9.0.0"
+    "@playwright/test": "1.55.0",
+    "@types/node": "24.3.0",
+    "typescript": "5.9.2"
   }
 }

--- a/template/go.mod.template
+++ b/template/go.mod.template
@@ -1,8 +1,6 @@
 module PROJECT_NAME
 
-go 1.24.5
-
-toolchain go1.24.5
+go 1.25.0
 
 require (
 	cloud.google.com/go/spanner v1.82.0

--- a/template/tests/global-setup.ts
+++ b/template/tests/global-setup.ts
@@ -1,5 +1,3 @@
-import { runMake } from './test-utils';
-
 /**
  * Simplified global setup for Playwright tests
  * Relies on Makefile to manage the Spanner emulator setup

--- a/template/tests/test-utils.ts
+++ b/template/tests/test-utils.ts
@@ -18,7 +18,7 @@ export function runCommand(command: string, args: string[] = []): string {
 
 // Run make command
 export function runMake(target: string): string {
-  return runCommand('/usr/bin/make', [target]);
+  return runCommand('make', [target]);
 }
 
 // Validate database ID format


### PR DESCRIPTION
## Summary
- Delete unused removeSecondaryDbFiles and its tests
- Stop conditional deletion of secondary DB example files; keep templates consistent
- Update template README to use `make test` and simplify instructions
- Pin template devDependencies to modern versions
- Update `go.mod.template` to go 1.25.0
- Simplify test utils to use PATH `make`

## Rationale
Unifies 1-DB/2-DB paths without ad-hoc file deletion, reduces maintenance, and aligns template tooling versions with repo standards.

## Test plan
- pnpm run build: succeeded
- pnpm test: all unit tests passed
- E2E script: generated a project, initialized, started emulator, and ran all scenarios successfully (3/3 passed)